### PR TITLE
Update gain maximum power audio qualcomm

### DIFF
--- a/rootdir/system/etc/snd_soc_msm/snd_soc_msm_2x
+++ b/rootdir/system/etc/snd_soc_msm/snd_soc_msm_2x
@@ -3470,10 +3470,10 @@ SectionDevice
 		'RX2 MIX1 INP1':0:RX2
 		'HPHL DAC Switch':1:1
 		'HPHR DAC Switch':1:1
-		'HPHL Volume':1:80
-		'HPHR Volume':1:80
-		'RX1 Digital Volume':1:68
-		'RX2 Digital Volume':1:68
+		'HPHL Volume':1:100
+		'HPHR Volume':1:100
+		'RX1 Digital Volume':1:72
+		'RX2 Digital Volume':1:72
 	EndSequence
 
 	DisableSequence


### PR DESCRIPTION
Gain maximum power that hw can rich high volume for 32 oms (lower volume on headphones/headset e.g SONY MH1c)
